### PR TITLE
Added a :raise_exceptions option and re-factored some of do_request

### DIFF
--- a/lib/madmimi.rb
+++ b/lib/madmimi.rb
@@ -56,7 +56,7 @@ class MadMimi
   end
   
   def raise_exceptions
-    options[:raise_exceptions]
+    @api_settings[:raise_exceptions]
   end
 
   def username


### PR DESCRIPTION
I wanted to be able to throw requests into delayed_job and let that handle failures so I added a raise_exceptions option to initialize so dj would know when a request failed. 

I also added a response attr_reader as I'd seen people wanting to know what the response was.

Also removed the rescue SocketError; raise 'Host unavailable' as it seems to just be masking things and thought it better to let it bubble up.

James
