### PR TITLE
Config options

### DIFF
--- a/spec/madmimi_spec.rb
+++ b/spec/madmimi_spec.rb
@@ -921,7 +921,7 @@ describe MadMimi do
 
   context '#send_mail' do
     context 'when options are correct' do
-      let(:default_options) {
+      let(:mailer_options) {
         {
           :promotion_name => 'Transactional Promotion',
           :from => 'maxim+1@madmimi.com',
@@ -931,7 +931,7 @@ describe MadMimi do
 
       context 'when sending to list', :vcr => { :cassette_name => 'send_mail/send_to_list' } do
         subject {
-          mad_mimi.send_mail(default_options.merge(:list_name => 'list 1'), {})
+          mad_mimi.send_mail(mailer_options.merge(:list_name => 'list 1'), {})
         }
 
         it "returns mailing id" do
@@ -941,7 +941,7 @@ describe MadMimi do
 
       context 'when sending to all', :vcr => { :cassette_name => 'send_mail/send_to_all' } do
         subject {
-          mad_mimi.send_mail(default_options.merge(:to_all => true), {})
+          mad_mimi.send_mail(mailer_options.merge(:to_all => true), {})
         }
 
         it "returns mailing id" do
@@ -951,7 +951,7 @@ describe MadMimi do
 
       context 'when sending to single recipient', :vcr => { :cassette_name => 'send_mail/send_single' } do
         subject {
-          mad_mimi.send_mail(default_options.merge(:recipient => 'Test Example <test@example.com>'), {})
+          mad_mimi.send_mail(mailer_options.merge(:recipient => 'Test Example <test@example.com>'), {})
         }
 
         it "returns transaction id" do
@@ -980,7 +980,7 @@ describe MadMimi do
     let(:raw_html) { '<html><body>Test [[tracking_beacon]] [[opt_out]]</body></html>' }
 
     context 'when options are correct' do
-      let(:default_options) {
+      let(:mailer_options) {
         {
           :promotion_name => 'Transactional Promotion',
           :from => 'maxim+1@madmimi.com',
@@ -990,7 +990,7 @@ describe MadMimi do
 
       context 'when sending to list', :vcr => { :cassette_name => 'send_html/send_to_list' } do
         subject {
-          mad_mimi.send_html(default_options.merge(:list_name => 'list 1'), raw_html)
+          mad_mimi.send_html(mailer_options.merge(:list_name => 'list 1'), raw_html)
         }
 
         it "returns mailing id" do
@@ -1000,7 +1000,7 @@ describe MadMimi do
 
       context 'when sending to all', :vcr => { :cassette_name => 'send_html/send_to_all' } do
         subject {
-          mad_mimi.send_html(default_options.merge(:to_all => true), raw_html)
+          mad_mimi.send_html(mailer_options.merge(:to_all => true), raw_html)
         }
 
         it "returns mailing id" do
@@ -1010,7 +1010,7 @@ describe MadMimi do
 
       context 'when sending to single recipient', :vcr => { :cassette_name => 'send_html/send_single' } do
         subject {
-          mad_mimi.send_html(default_options.merge(:recipient => 'Test Example <test@example.com>'), raw_html)
+          mad_mimi.send_html(mailer_options.merge(:recipient => 'Test Example <test@example.com>'), raw_html)
         }
 
         it "returns transaction id" do
@@ -1073,7 +1073,7 @@ describe MadMimi do
     let(:plain_text) { 'Test [[tracking_beacon]] [[opt_out]]' }
 
     context 'when options are correct' do
-      let(:default_options) {
+      let(:mailer_options) {
         {
           :promotion_name => 'Transactional Promotion',
           :from => 'maxim+1@madmimi.com',
@@ -1083,7 +1083,7 @@ describe MadMimi do
 
       context 'when sending to list', :vcr => { :cassette_name => 'send_plaintext/send_to_list' } do
         subject {
-          mad_mimi.send_plaintext(default_options.merge(:list_name => 'list 1'), plain_text)
+          mad_mimi.send_plaintext(mailer_options.merge(:list_name => 'list 1'), plain_text)
         }
 
         it "returns mailing id" do
@@ -1093,7 +1093,7 @@ describe MadMimi do
 
       context 'when sending to all', :vcr => { :cassette_name => 'send_plaintext/send_to_all' } do
         subject {
-          mad_mimi.send_plaintext(default_options.merge(:to_all => true), plain_text)
+          mad_mimi.send_plaintext(mailer_options.merge(:to_all => true), plain_text)
         }
 
         it "returns mailing id" do
@@ -1103,7 +1103,7 @@ describe MadMimi do
 
       context 'when sending to single recipient', :vcr => { :cassette_name => 'send_plaintext/send_single' } do
         subject {
-          mad_mimi.send_plaintext(default_options.merge(:recipient => 'Test Example <test@example.com>'), plain_text)
+          mad_mimi.send_plaintext(mailer_options.merge(:recipient => 'Test Example <test@example.com>'), plain_text)
         }
 
         it "returns transaction id" do

--- a/spec/madmimi_spec.rb
+++ b/spec/madmimi_spec.rb
@@ -39,6 +39,25 @@ describe MadMimi do
         expect(subject.raise_exceptions?).to be_truthy
       end
     end
+
+    context 'changing initialization settings' do
+      let(:mad_mimi) { MadMimi.new('USERNAME', 'APIKEY', { raise_exceptions: false, verify_ssl: false }) }
+      subject { mad_mimi }
+      
+      context 'for raise_exceptions' do
+        before(:each) { mad_mimi.raise_exceptions = true }
+        it 'should change raise_exceptions to true' do
+          expect(subject.raise_exceptions?).to be_truthy
+        end
+      end
+
+      context 'for verify_ssl' do
+        before(:each) { mad_mimi.verify_ssl = true }
+        it 'should change verify_ssl to true' do
+          expect(subject.verify_ssl?).to be_truthy
+        end
+      end
+    end
   end
 
   context '#lists', :vcr => { :cassette_name => 'lists' } do


### PR DESCRIPTION
Refactors config options to make it possible to pass options to HTTParty, e.g.

```
MadMimi.new('USERNAME', 'APIKEY', { raise_exceptions: true, verify_ssl: false, read_timeout: 60 }
```

Open to suggestions on how to test this without mocking HTTParty.
