### PR TITLE
Ruby 3 - URI.escape

### DIFF
--- a/lib/madmimi.rb
+++ b/lib/madmimi.rb
@@ -354,7 +354,7 @@ class MadMimi
   end
 
   def path(key, arguments={})
-    escaped_arguments = arguments.inject({}){ |h, (k, v)| h[k] = URI.escape(v.to_s); h }
+    escaped_arguments = arguments.inject({}){ |h, (k, v)| h[k] = CGI.escape(v.to_s); h }
     paths[key] % escaped_arguments
   end
 


### PR DESCRIPTION
in Ruby 3, URI escape is no longer supported, a simple fix is CGI escape